### PR TITLE
More fixes

### DIFF
--- a/crates/argmin-math/Cargo.toml
+++ b/crates/argmin-math/Cargo.toml
@@ -22,6 +22,7 @@ nalgebra_0_29 = { package = "nalgebra", version = "0.29", optional = true }
 
 # ndarray
 ndarray_0_16 = { package = "ndarray", version = "0.16", optional = true }
+ndarray-linalg_0_17 = { package = "ndarray-linalg", version = "0.17", optional = true }
 ## v0.15
 ndarray_0_15 = { package = "ndarray", version = "0.15", optional = true }
 ndarray-linalg_0_16 = { package = "ndarray-linalg", version = "0.16", optional = true }
@@ -71,7 +72,7 @@ ndarray_all = ["primitives"]
 ndarray_latest = ["ndarray_v0_16"]
 
 ## With `ndarray-linalg`
-ndarray_v0_16 = ["ndarray_0_16", "ndarray-linalg_0_16", "num-complex_0_4", "ndarray_all"]
+ndarray_v0_16 = ["ndarray_0_16", "ndarray-linalg_0_17", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_15 = ["ndarray_0_15", "ndarray-linalg_0_16", "num-complex_0_4", "ndarray_all"]
 ndarray_v0_14 = ["ndarray_0_14", "ndarray-linalg_0_13", "num-complex_0_3", "ndarray_all"]
 ndarray_v0_13 = ["ndarray_0_13", "ndarray-linalg_0_12", "num-complex_0_2", "ndarray_all"]

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_13/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_13/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "*" # Should unify with whatever is currently used in argmin itself
+rand = "0.8"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_14/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_14/Cargo.toml
@@ -19,7 +19,7 @@ num-integer = { version = "0.1" }
 anyhow = { version = "<=1.0.48" }
 paste = "1"
 approx = "0.5.0"
-rand = "*" # Should unify with whatever is currently used in argmin itself
+rand = "0.8"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_15/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "*" # Should unify with whatever is currently used in argmin itself
+rand = "0.8"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
@@ -11,7 +11,7 @@ argmin-math = { path = "../../", version = "*", features = [
     "ndarray_v0_16",
 ] }
 ndarray = { version = "0.16", default-features = false }
-ndarray-linalg = { version = "0.16", default-features = false, features = ["intel-mkl-static"] }
+ndarray-linalg = { version = "0.17", default-features = false, features = ["intel-mkl-static"] }
 num-complex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_0_16/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "*" # Should unify with whatever is currently used in argmin itself
+rand = "0.8"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }
 paste = "1"
 approx = "0.5.0"
-rand = "*" # Should unify with whatever is currently used in argmin itself
+rand = "0.8"
 
 [features]
 

--- a/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
+++ b/crates/argmin-math/ndarray-linalg-tests/ndarray_latest/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 argmin-math = { path = "../../", version = "*", features = [
     "ndarray_latest",
 ] }
-ndarray = { version = "0.15", default-features = false }
-ndarray-linalg = { version = "0.16", default-features = false, features = ["intel-mkl-static"] }
+ndarray = { version = "0.16", default-features = false }
+ndarray-linalg = { version = "0.17", default-features = false, features = ["intel-mkl-static"] }
 num-complex = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }

--- a/crates/argmin-math/src/lib.rs
+++ b/crates/argmin-math/src/lib.rs
@@ -175,7 +175,9 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "ndarray-linalg_0_16")] {
+    if #[cfg(feature = "ndarray-linalg_0_17")] {
+        extern crate ndarray_linalg_0_17 as ndarray_linalg;
+    } else if #[cfg(feature = "ndarray-linalg_0_16")] {
         extern crate ndarray_linalg_0_16 as ndarray_linalg;
     } else if #[cfg(feature = "ndarray-linalg_0_13")] {
         extern crate ndarray_linalg_0_13 as ndarray_linalg;

--- a/crates/argmin-math/src/ndarray_m/mod.rs
+++ b/crates/argmin-math/src/ndarray_m/mod.rs
@@ -15,7 +15,8 @@ mod eye;
 #[cfg(any(
     feature = "ndarray-linalg_0_12",
     feature = "ndarray-linalg_0_13",
-    feature = "ndarray-linalg_0_16"
+    feature = "ndarray-linalg_0_16",
+    feature = "ndarray-linalg_0_17",
 ))]
 mod inv;
 mod l1norm;
@@ -38,7 +39,8 @@ pub use eye::*;
 #[cfg(any(
     feature = "ndarray-linalg_0_12",
     feature = "ndarray-linalg_0_13",
-    feature = "ndarray-linalg_0_16"
+    feature = "ndarray-linalg_0_16",
+    feature = "ndarray-linalg_0_17",
 ))]
 pub use inv::*;
 pub use l1norm::*;

--- a/crates/argmin/Cargo.toml
+++ b/crates/argmin/Cargo.toml
@@ -34,7 +34,7 @@ approx = "0.5.0"
 finitediff = { version = "0.1.4", features = ["ndarray"] }
 argmin_testfunctions = { version = "0.2.0", path = "../argmin-testfunctions" }
 ndarray = { version = "0.16", features = ["serde-1"] }
-ndarray-linalg = { version = "0.16", features = ["intel-mkl-static"] }
+ndarray-linalg = { version = "0.17", features = ["intel-mkl-static"] }
 argmin-math = { path = "../argmin-math", version = "0.3", features = ["vec"] }
 argmin-observer-slog = { path = "../argmin-observer-slog" }
 argmin-observer-paramwriter = { path = "../argmin-observer-paramwriter" }

--- a/examples/bfgs/Cargo.toml
+++ b/examples/bfgs/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/dfp/Cargo.toml
+++ b/examples/dfp/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/gaussnewton/Cargo.toml
+++ b/examples/gaussnewton/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
-ndarray = "0.15.6"
-ndarray-linalg = { version = "0.16.0", features = ["intel-mkl"] }
+ndarray = "0.16"
+ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }

--- a/examples/gaussnewton_linesearch/Cargo.toml
+++ b/examples/gaussnewton_linesearch/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
-ndarray = "0.15.6"
-ndarray-linalg = { version = "0.16.0", features = ["intel-mkl"] }
+ndarray = "0.16"
+ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }

--- a/examples/lbfgs/Cargo.toml
+++ b/examples/lbfgs/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/neldermead/Cargo.toml
+++ b/examples/neldermead/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/newton/Cargo.toml
+++ b/examples/newton/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.15.6"
-ndarray-linalg = { version = "0.16.0", features = ["intel-mkl"] }
+ndarray = "0.16"
+ndarray-linalg = { version = "0.17.0", features = ["intel-mkl"] }

--- a/examples/newton_cg/Cargo.toml
+++ b/examples/newton_cg/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/owl_qn/Cargo.toml
+++ b/examples/owl_qn/Cargo.toml
@@ -10,4 +10,4 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/sr1/Cargo.toml
+++ b/examples/sr1/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/sr1_trustregion/Cargo.toml
+++ b/examples/sr1_trustregion/Cargo.toml
@@ -11,4 +11,4 @@ argmin-math = { version = "*", features = ["ndarray_latest-nolinalg"], path = ".
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
 finitediff = { version = "0.1.4", features = ["ndarray"] }
-ndarray = "0.15.6"
+ndarray = "0.16"

--- a/examples/trustregion/Cargo.toml
+++ b/examples/trustregion/Cargo.toml
@@ -10,5 +10,5 @@ argmin = { version = "*", path = "../../crates/argmin" }
 argmin-math = { version = "*", features = ["ndarray_latest"], path = "../../crates/argmin-math" }
 argmin-observer-slog = { version = "*", path = "../../crates/argmin-observer-slog" }
 argmin_testfunctions = { version = "*", path = "../../crates/argmin-testfunctions" }
-ndarray = "0.15.6"
-ndarray-linalg = { version = "0.16.0", features = ["intel-mkl-static"] }
+ndarray = "0.16"
+ndarray-linalg = { version = "0.17.0", features = ["intel-mkl-static"] }


### PR DESCRIPTION
https://github.com/rust-ndarray/ndarray-linalg/issues/391#issuecomment-2621980505 Has been merged, and we can continue the upgrades! argmin itself can now pass all tests on my computer with `cargo t --all-features`, and argmin-math is passing `cargo t --features=ndarray_v0_16`.
Some of the examples can't compile now that I bumped them to 0.16, because https://github.com/argmin-rs/finitediff/ doesn't have a release that depends on ndarray 0.16 on crates.io. The support is merged on the main branch though, so it should be easy for Stefan to just release a new version of that.


